### PR TITLE
fixed typo in Graph Application permissions Sites.Read.All

### DIFF
--- a/docs/addinsacs/requirements.md
+++ b/docs/addinsacs/requirements.md
@@ -8,7 +8,7 @@ When using the SharePoint Add-In and Azure ACS module of the Microsoft 365 Asses
 
 Authentication | Minimal
 ---------------| -------
-Application | **Graph:** Sites.Read.Al, Application.Read.All <br> **SharePoint:** Sites.Read.All
+Application | **Graph:** Sites.Read.All, Application.Read.All <br> **SharePoint:** Sites.Read.All
 Delegated | **Graph:** Sites.Read.All, Application.Read.All, User.Read <br> **SharePoint:** AllSites.Read
 
 > [!Important]


### PR DESCRIPTION
fixed typo in Graph Application permissions 
missing "L" at the end of Sites.Read.All